### PR TITLE
feat: pending indicator, explainer, and event-driven roster for member-add

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,17 +6,17 @@
         "logos-module-builder": "logos-module-builder_4"
       },
       "locked": {
-        "lastModified": 1783668326,
-        "narHash": "sha256-7yLbzqRtpLHRFFT2R3n+sijJhoErFkRX2Qp2XBbsy4A=",
+        "lastModified": 1784188525,
+        "narHash": "sha256-sVTjOkloEla7hDKEQ3b1MAJQ92W/l4uXyQoq3xjYGsE=",
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "c9542d8fa719dbcb04a1b099986256500b20d56a",
+        "rev": "2354fecb26183714ecd0aa174cf57ee1d544125f",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "c9542d8fa719dbcb04a1b099986256500b20d56a",
+        "rev": "2354fecb26183714ecd0aa174cf57ee1d544125f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,11 @@
     # logos-protocol/logos-qt-sdk chain matches across both.
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";
-    # Pinned to the merged GroupV2 commit on chat_module master (#43); re-pin
-    # whenever chat_module advances, and switch to a release tag once one is
-    # cut. Delivery stays on the v0.1.3 tag below, matching chat_module's own
-    # delivery pin.
-    chat_module.url = "github:logos-co/logos-chat-module/c9542d8fa719dbcb04a1b099986256500b20d56a";
+    # Pinned to the chat_module master commit that surfaces the members_changed
+    # event; re-pin whenever chat_module advances, and switch to a release tag
+    # once one is cut. Delivery stays on the v0.1.3 tag below, matching
+    # chat_module's own delivery pin.
+    chat_module.url = "github:logos-co/logos-chat-module/2354fecb26183714ecd0aa174cf57ee1d544125f";
     # Pinned to the v0.1.3 release tag, which includes the zerokit/RLN nix build
     # fix (delivery-module #49: zerokit's cargo vendor no longer hits crates.io's
     # python-requests 403). Kept in lockstep with chat_module's delivery pin.

--- a/src/ChatBackend.cpp
+++ b/src/ChatBackend.cpp
@@ -7,12 +7,14 @@
 // metadata.json#dependencies — the Qt-typed chat_module wrapper.
 #include "logos_sdk.h"
 
+#include <QCoreApplication>
 #include <QDateTime>
 #include <QDebug>
 #include <QDir>
 #include <QStandardPaths>
 #include <QVariantMap>
 #include <cstdlib>
+#include <utility>
 
 namespace {
 
@@ -27,6 +29,18 @@ QDateTime msToDateTime(qint64 ms)
 }
 
 } // namespace
+
+// QtCore Settings (QSettings) persists only when the application has an
+// identity, and the module host does not always set one. Provide a fallback so
+// UI preferences survive restarts, leaving a host-set identity untouched.
+static void ensureApplicationIdentity()
+{
+    if (QCoreApplication::organizationName().isEmpty())
+        QCoreApplication::setOrganizationName(QStringLiteral("Logos"));
+    if (QCoreApplication::applicationName().isEmpty())
+        QCoreApplication::setApplicationName(QStringLiteral("logos-chat-ui"));
+}
+Q_COREAPP_STARTUP_FUNCTION(ensureApplicationIdentity)
 
 ChatBackend::ChatBackend(QObject* parent)
     : ChatBackendSimpleSource(parent)
@@ -164,6 +178,8 @@ void ChatBackend::subscribeToEvents()
             [this](const QVariantList& a) { applyConversationCreated(a); });
     chat.on(QStringLiteral("conversation_updated"),
             [this](const QVariantList& a) { applyConversationUpdated(a); });
+    chat.on(QStringLiteral("members_changed"),
+            [this](const QVariantList& a) { applyMembersChanged(a); });
     chat.on(QStringLiteral("conversation_deleted"),
             [this](const QVariantList& a) { applyConversationDeleted(a); });
     chat.on(QStringLiteral("delivery_state_changed"), [this](const QVariantList& a) {
@@ -292,8 +308,12 @@ void ChatBackend::addGroupMember(QString conversationId, QString peerAddress)
         emit error(QStringLiteral("Failed to add member: ") + reason);
         return;
     }
-    // The add is committed and the welcome delivered asynchronously, so be
-    // honest that the peer is not in the group yet.
+    // The commit is async, so the peer isn't in the group yet. Show it as a
+    // pending busy row; the members_changed event reconciles it once committed.
+    if (conversationId == currentConversationId()) {
+        m_pendingMembers.insert(peerAddress);
+        refreshMembers();
+    }
     setStatusMessage(QStringLiteral("Invite sent; peer joins when the group commits"));
 }
 
@@ -346,6 +366,7 @@ void ChatBackend::selectConversation(QString conversationId)
     // members. refreshMembers then loads the new group's roster when it can, and
     // keeps the last-known one across a transient offline of the same group.
     // User-driven, so its synchronous read is safe here (not in an event callback).
+    m_pendingMembers.clear();
     m_memberModel->clear();
     setMemberCount(0);
     refreshMembers();
@@ -370,15 +391,24 @@ void ChatBackend::refreshMembers()
     const QVariantList members = modules().chat_module.list_group_members(convoId);
     QVector<MemberItem> rows;
     rows.reserve(members.size());
+    QSet<QString> committed;
     for (const QVariant& v : members) {
         const QString address = v.toMap().value(QStringLiteral("address")).toString();
         // An empty address is the roster's "no confirmed account" signal; keep
         // it — the model renders it as "unknown_account". Only a real account
         // address can be self.
-        rows.append({ address, !address.isEmpty() && address == m_myAddress });
+        rows.append({ address, !address.isEmpty() && address == m_myAddress, false });
+        if (!address.isEmpty())
+            committed.insert(address);
     }
+    // Drop invites that have since committed; show the rest as busy rows.
+    m_pendingMembers.subtract(committed);
+    for (const QString& address : std::as_const(m_pendingMembers))
+        rows.append({ address, false, true });
+
     m_memberModel->setMembers(rows);
-    setMemberCount(static_cast<int>(rows.size()));
+    // Committed roster size only; pending invites appear in the list but aren't counted.
+    setMemberCount(static_cast<int>(members.size()));
 }
 
 // ── event handlers ────────────────────────────────────────────────────────────
@@ -508,6 +538,16 @@ void ChatBackend::applyConversationUpdated(const QVariantList& args)
         rehydrateConversations();
         // A group update (e.g. a member added) may have grown the roster of the
         // conversation on screen; refetch it.
+        if (convoId == currentConversationId() && m_conversationModel->isGroupFor(convoId))
+            refreshMembers();
+    });
+}
+
+void ChatBackend::applyMembersChanged(const QVariantList& args)
+{
+    const QString convoId = args.value(0).toString();
+    // A commit changed this group's roster; refetch it if it is on screen.
+    deferToEventLoop([this, convoId] {
         if (convoId == currentConversationId() && m_conversationModel->isGroupFor(convoId))
             refreshMembers();
     });

--- a/src/ChatBackend.h
+++ b/src/ChatBackend.h
@@ -2,6 +2,7 @@
 #define CHAT_BACKEND_H
 
 #include <QObject>
+#include <QSet>
 #include <QString>
 #include <QVariantList>
 #include <functional>
@@ -75,6 +76,7 @@ private:
     void applyMessageSent(const QVariantList& args);
     void applyConversationCreated(const QVariantList& args);
     void applyConversationUpdated(const QVariantList& args);
+    void applyMembersChanged(const QVariantList& args);
     void applyConversationDeleted(const QVariantList& args);
 
     static QString fallbackDisplayName(const QString& convoId, const QString& peerLabel = QString(),
@@ -91,6 +93,8 @@ private:
     // This installation's own address, cached lazily on first roster refresh to
     // mark the self entry.
     QString m_myAddress;
+    // Addresses invited into the current group but not yet committed to its roster.
+    QSet<QString> m_pendingMembers;
     bool m_moduleInitialised = false;
     // Set once the initial snapshot has loaded; gates the reconnect resync in
     // applyDeliveryState so it doesn't fire during initial setup.

--- a/src/MemberListModel.cpp
+++ b/src/MemberListModel.cpp
@@ -25,6 +25,7 @@ QVariant MemberListModel::data(const QModelIndex& index, int role) const
                           ? QStringLiteral("unknown_account")
                           : item.address.left(8);
     case IsSelfRole:  return item.isSelf;
+    case PendingRole: return item.pending;
     default:          return {};
     }
 }
@@ -34,7 +35,8 @@ QHash<int, QByteArray> MemberListModel::roleNames() const
     return {
         { AddressRole, "address" },
         { LabelRole,   "label" },
-        { IsSelfRole,  "isSelf" }
+        { IsSelfRole,  "isSelf" },
+        { PendingRole, "pending" }
     };
 }
 

--- a/src/MemberListModel.h
+++ b/src/MemberListModel.h
@@ -11,6 +11,8 @@ struct MemberItem {
     QString address;
     // True for this installation's own entry in the roster.
     bool isSelf = false;
+    // A member invited but not yet committed into the group.
+    bool pending = false;
 };
 
 // A group's roster, replaced wholesale on each refresh. `label` is the short
@@ -24,7 +26,8 @@ public:
     enum Roles {
         AddressRole = Qt::UserRole + 1,
         LabelRole,
-        IsSelfRole
+        IsSelfRole,
+        PendingRole
     };
 
     explicit MemberListModel(QObject* parent = nullptr);

--- a/src/qml/ChatUi/ChatStore.qml
+++ b/src/qml/ChatUi/ChatStore.qml
@@ -73,10 +73,6 @@ QtObject {
         if (backend && currentConversationId !== "")
             backend.addGroupMember(currentConversationId, address);
     }
-    function refreshMembers() {
-        if (backend)
-            backend.refreshMembers();
-    }
 
     property Connections _backendSignals: Connections {
         target: root.backend

--- a/src/qml/ChatUi/MemberAddInfoDialog.qml
+++ b/src/qml/ChatUi/MemberAddInfoDialog.qml
@@ -1,0 +1,64 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Logos.Theme
+import Logos.Controls
+
+// First-time explainer for adding a group member: the commit is asynchronous, so
+// a newly invited member can take up to a minute to appear. Open it, and connect
+// confirmed() — it carries whether the user ticked "Don't show this again", so the
+// caller can persist that and skip the dialog next time. Standalone: instantiate
+// with no context, open(), and read the signal.
+LogosDialog {
+    id: root
+
+    // Emitted when the user confirms the add; `dontShowAgain` is the checkbox state.
+    signal confirmed(bool dontShowAgain)
+
+    title: qsTr("Adding a member")
+    modal: true
+    focus: true
+    closePolicy: Popup.CloseOnEscape
+    anchors.centerIn: Overlay.overlay
+    width: Math.min(480, (Overlay.overlay ? Overlay.overlay.width : 480) - 2 * Theme.spacing.large)
+
+    leftActions: [
+        LogosButton {
+            implicitWidth: 96
+            implicitHeight: 36
+            text: qsTr("Cancel")
+            onClicked: root.close()
+        }
+    ]
+    rightActions: [
+        LogosButton {
+            implicitWidth: 130
+            implicitHeight: 36
+            //: Button that confirms inviting the member into the group
+            text: qsTr("Add member")
+            onClicked: {
+                root.confirmed(dontShowAgain.checked);
+                root.close();
+            }
+        }
+    ]
+
+    contentItem: ColumnLayout {
+        spacing: Theme.spacing.medium
+
+        LogosText {
+            //: Explains that group membership commits asynchronously (deMLS)
+            text: qsTr("Adding a member isn't synchronous. The group commits the membership change (deMLS) on a timer, so a new member can take up to a minute to appear.")
+            color: Theme.palette.textSecondary
+            font.pixelSize: Theme.typography.secondaryText
+            wrapMode: Text.WordWrap
+            Layout.fillWidth: true
+        }
+
+        LogosCheckbox {
+            id: dontShowAgain
+            text: qsTr("Don't show this again")
+        }
+    }
+}

--- a/src/qml/ChatUi/MemberDelegate.qml
+++ b/src/qml/ChatUi/MemberDelegate.qml
@@ -5,13 +5,17 @@ import Logos.Theme
 import Logos.Controls
 
 // A group-roster row: the member label with a self marker, revealing the full
-// address on hover and requesting a copy on click. Delegate roles bind by name.
+// address on hover and requesting a copy on click. A pending member (invited but
+// not yet committed to the roster) dims and shows a busy spinner. Delegate roles
+// bind by name.
 LogosItemDelegate {
     id: root
 
     required property string label
     required property string address
     required property bool isSelf
+    // Invited but not yet committed into the group's roster.
+    required property bool pending
 
     signal copyRequested(string address)
 
@@ -30,10 +34,21 @@ LogosItemDelegate {
         LogosText {
             text: root.label
             textFormat: Text.PlainText
-            color: Theme.palette.text
+            color: root.pending ? Theme.palette.textSecondary : Theme.palette.text
             font.pixelSize: Theme.typography.secondaryText
             elide: Text.ElideRight
             Layout.fillWidth: true
+        }
+
+        LogosSpinner {
+            visible: root.pending
+            running: root.pending
+            ringColor: Theme.palette.border
+            thickness: 2
+            dotSize: 5
+            Layout.preferredWidth: 14
+            Layout.preferredHeight: 14
+            Layout.alignment: Qt.AlignVCenter
         }
 
         LogosText {
@@ -47,8 +62,9 @@ LogosItemDelegate {
     }
 
     LogosToolTip {
-        text: root.address
+        //: Tooltip on a member still being committed into the group
+        text: root.pending ? qsTr("waiting for commit") : root.address
         placement: LogosToolTip.Left
-        visible: root.hovered && root.address !== ""
+        visible: root.hovered && (root.pending || root.address !== "")
     }
 }

--- a/src/qml/ChatUi/MembersPane.qml
+++ b/src/qml/ChatUi/MembersPane.qml
@@ -6,7 +6,6 @@ import QtQuick.Layouts
 
 import Logos.Theme
 import Logos.Controls
-import Logos.Icons
 
 // Group-roster panel: give it a member model and an online flag, and connect its
 // signals. A row shows the member label and a self marker, reveals the full
@@ -21,8 +20,6 @@ Rectangle {
 
     // Emitted when the user asks to invite `address` into the group.
     signal addMemberRequested(string address)
-    // Emitted when the user asks to reload the roster.
-    signal refreshRequested
 
     implicitWidth: 220
     color: Theme.palette.backgroundInset
@@ -38,22 +35,6 @@ Rectangle {
         PaneHeader {
             Layout.fillWidth: true
             title: qsTr("Members")
-
-            LogosIconButton {
-                id: refreshButton
-                size: 30
-                iconSize: 16
-                iconSource: LogosIcons.refresh
-                enabled: root.online
-                onClicked: root.refreshRequested()
-                Layout.alignment: Qt.AlignVCenter
-
-                LogosToolTip {
-                    text: qsTr("Reload roster")
-                    placement: LogosToolTip.Bottom
-                    visible: refreshButton.hovered
-                }
-            }
         }
 
         ListView {

--- a/src/qml/ChatUi/qmldir
+++ b/src/qml/ChatUi/qmldir
@@ -15,3 +15,4 @@ MessageThreadPane 1.0 MessageThreadPane.qml
 MembersPane 1.0 MembersPane.qml
 NewConversationDialog 1.0 NewConversationDialog.qml
 AddressDialog 1.0 AddressDialog.qml
+MemberAddInfoDialog 1.0 MemberAddInfoDialog.qml

--- a/src/qml/ChatView.qml
+++ b/src/qml/ChatView.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtCore
 import QtQuick.Layouts
 
 import ChatUi
@@ -74,9 +75,14 @@ Item {
                 memberModel: store.memberModel
                 online: store.online
                 onAddMemberRequested: function (address) {
-                    store.addMember(address);
+                    // First member add: explain the async commit delay first, then invite.
+                    if (chatPrefs.memberAddExplained) {
+                        store.addMember(address);
+                    } else {
+                        memberAddInfoDialog.pendingAddress = address;
+                        memberAddInfoDialog.open();
+                    }
                 }
-                onRefreshRequested: store.refreshMembers()
             }
         }
 
@@ -101,7 +107,27 @@ Item {
         id: addressDialog
     }
 
+    MemberAddInfoDialog {
+        id: memberAddInfoDialog
+        // The address whose add opened the explainer, applied once confirmed.
+        property string pendingAddress: ""
+        onConfirmed: function (dontShowAgain) {
+            if (dontShowAgain)
+                chatPrefs.memberAddExplained = true;
+            if (pendingAddress !== "")
+                store.addMember(pendingAddress);
+            pendingAddress = "";
+        }
+    }
+
     Toast {
         id: toast
+    }
+
+    // Persisted UI preferences.
+    Settings {
+        id: chatPrefs
+        category: "chat_ui"
+        property bool memberAddExplained: false
     }
 }

--- a/tests/qml/tst_components.qml
+++ b/tests/qml/tst_components.qml
@@ -49,6 +49,7 @@ Item {
             address: "0xabc"
             label: "Alice"
             isSelf: false
+            pending: false
         }
     }
 
@@ -125,6 +126,10 @@ Item {
         AddressDialog {}
     }
     Component {
+        id: memberAddInfoDialogC
+        MemberAddInfoDialog {}
+    }
+    Component {
         id: conversationDelegateC
         ConversationDelegate {
             conversationId: "c1"
@@ -145,6 +150,15 @@ Item {
             groupContext: true
         }
     }
+    Component {
+        id: memberDelegateC
+        MemberDelegate {
+            label: "Carol"
+            address: "0xcarol"
+            isSelf: false
+            pending: true
+        }
+    }
 
     SignalSpy {
         id: submitSpy
@@ -153,6 +167,10 @@ Item {
     SignalSpy {
         id: addressSpy
         signalName: "addressEntered"
+    }
+    SignalSpy {
+        id: confirmedSpy
+        signalName: "confirmed"
     }
 
     TestCase {
@@ -190,11 +208,13 @@ Item {
         function test_dialogsInstantiate() {
             instantiate(newConvDialogC);
             instantiate(addressDialogC);
+            instantiate(memberAddInfoDialogC);
         }
 
         function test_delegatesInstantiate() {
             instantiate(conversationDelegateC);
             instantiate(messageBubbleC);
+            instantiate(memberDelegateC);
         }
 
         // The current conversation highlights; a different one does not.
@@ -234,6 +254,17 @@ Item {
             dlg._accept();
             compare(addressSpy.count, 0, "an empty address must not be accepted");
             dlg.close();
+        }
+
+        // Confirming the explainer emits confirmed() so the caller can proceed
+        // with the invite and persist the "don't show again" choice.
+        function test_memberAddInfoDialogConfirms() {
+            const dlg = instantiate(memberAddInfoDialogC);
+            confirmedSpy.target = dlg;
+            confirmedSpy.clear();
+            dlg.open();
+            dlg.rightActions[0].clicked();
+            compare(confirmedSpy.count, 1, "confirming must emit confirmed() once");
         }
     }
 }

--- a/tests/storybook/Storybook.qml
+++ b/tests/storybook/Storybook.qml
@@ -59,11 +59,19 @@ Rectangle {
             address: "0xalice"
             label: "Alice"
             isSelf: true
+            pending: false
         }
         ListElement {
             address: "0xbob"
             label: "Bob"
             isSelf: false
+            pending: false
+        }
+        ListElement {
+            address: "0xcarol"
+            label: "Carol"
+            isSelf: false
+            pending: true
         }
     }
 


### PR DESCRIPTION
Adding a member gave no feedback: the roster only showed the peer ~a commit later, and only via a manual refresh button or a message from them. The status bar was the sole hint the invite was in flight.

Show the invite immediately and let the module tell us when it lands.

- A just-invited member appears at once as a busy row (spinner, dimmed, tooltip "waiting for commit"), tracked in a per-conversation pending set. A roster refresh that finds the member in the committed roster drops the pending marker; the set is cleared on conversation switch.
- The roster now auto-refreshes from the module's members_changed event (surfaced from libchat), so a remote join updates the list with no user action. Bump the chat_module pin to the rev that emits it.
- Remove the members refresh button and its signal; the event replaces manual refresh.
- First time a user adds a member, an explainer dialog describes the commit delay, with a "Don't show this again" checkbox persisted via QtCore Settings.

---
Depends on the members_changed event from logos-co/logos-chat-module#47 (pinned by rev, chat_module flake input), which in turn depends on logos-messaging/libchat#177.
