### PR TITLE
chore(deps): pin chat_module to the v0.2.0 release tag

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,8 +15,8 @@
       },
       "original": {
         "owner": "logos-co",
+        "ref": "v0.2.0",
         "repo": "logos-chat-module",
-        "rev": "afb965589afb193a8559faf911233221a681af80",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,12 +6,9 @@
     # logos-protocol/logos-qt-sdk chain matches across both.
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";
-    # Pinned to the chat_module commit that adds a group name and description to
-    # create_group_conversation and surfaces them on the Conversation record and
-    # conversation_created event; re-pin whenever chat_module advances, and switch
-    # to a release tag once one is cut. Delivery stays on the v0.1.3 tag below,
+    # Pinned to the v0.2.0 release tag. Delivery stays on the v0.1.3 tag below,
     # matching chat_module's own delivery pin.
-    chat_module.url = "github:logos-co/logos-chat-module/afb965589afb193a8559faf911233221a681af80";
+    chat_module.url = "github:logos-co/logos-chat-module/v0.2.0";
     # Pinned to the v0.1.3 release tag, which includes the zerokit/RLN nix build
     # fix (delivery-module #49: zerokit's cargo vendor no longer hits crates.io's
     # python-requests 403). Kept in lockstep with chat_module's delivery pin.


### PR DESCRIPTION
chat_module v0.2.0 releases the commit this flake already pinned by raw rev, so the pin moves to the release tag; the locked rev is unchanged.