### PR TITLE
fix: keep a pending member on the roster across chat switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Conversations are **ephemeral** — messages and identity exist only while the a
 
 - **Group** creates a group with you as its only member (no dialog; the group opens immediately).
 - Collect peers' addresses (each shares theirs via **Show My Address**), paste one into the members panel's add-member field, and press **Add** to invite.
-- Membership changes are asynchronous: on devnet the group's steward commits an add only after a ~60s commit-inactivity window, then the welcome is delivered, so a peer joins **minutes** after the invite. The roster refreshes on selection, a message from a new member, the reload-roster button, or your own add.
+- Membership changes are asynchronous: on devnet the group's steward commits an add only after a ~60s commit-inactivity window, then the welcome is delivered, so a peer joins **minutes** after the invite. A peer you invited sits on the roster as a dimmed, spinning row until the group commits it, and stays there across chat switches. The roster refreshes on selection, a message from a new member, the reload-roster button, or your own add.
 - Any member can add another; the invite routes from whoever proposed it.
 - During the brief windows while the group is finalizing a membership change, de-mls rejects sends; these surface as an error toast, so retry after a moment.
 

--- a/flake.lock
+++ b/flake.lock
@@ -6,17 +6,17 @@
         "logos-module-builder": "logos-module-builder_4"
       },
       "locked": {
-        "lastModified": 1784736042,
-        "narHash": "sha256-wI+awNiKJaUgeZgQ/D0H9+iP0ZPMfafWP8G4yh+CH5A=",
+        "lastModified": 1784797831,
+        "narHash": "sha256-iHYEnCgbsNBzoy6gmfc0HtvjOVyif38p00w1LW3x948=",
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "4983eb7343057bc12d51f6e7067ffb9cb681403a",
+        "rev": "0678a31f956dc486172c6764fae99e98f6583f27",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "4983eb7343057bc12d51f6e7067ffb9cb681403a",
+        "rev": "0678a31f956dc486172c6764fae99e98f6583f27",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,9 @@
     # Follow chat_module's own builder, so the logos-protocol/logos-qt-sdk
     # chain matches across both.
     logos-module-builder.follows = "chat_module/logos-module-builder";
-    # Pinned to the chat_module rev whose init contract drops the delivery port;
+    # Pinned to the chat_module rev whose roster reports pending invites;
     # release tags predate it.
-    chat_module.url = "github:logos-co/logos-chat-module/4983eb7343057bc12d51f6e7067ffb9cb681403a";
+    chat_module.url = "github:logos-co/logos-chat-module/0678a31f956dc486172c6764fae99e98f6583f27";
     # Follow chat_module's delivery pin, so both build against the same
     # delivery module.
     logos-delivery-module.follows = "chat_module/logos-delivery-module";

--- a/src/ChatBackend.cpp
+++ b/src/ChatBackend.cpp
@@ -276,12 +276,10 @@ void ChatBackend::addGroupMember(QString conversationId, QString peerAddress)
         emit error(QStringLiteral("Failed to add member: ") + reason);
         return;
     }
-    // The commit is async, so the peer isn't in the group yet. Show it as a
-    // pending busy row; the members_changed event reconciles it once committed.
-    if (conversationId == currentConversationId()) {
-        m_pendingMembers.insert(peerAddress);
+    // The commit is async, so the peer joins the roster as a pending busy row;
+    // the members_changed event reconciles it once committed.
+    if (conversationId == currentConversationId())
         refreshMembers();
-    }
     setStatusMessage(QStringLiteral("Invite sent; peer joins when the group commits"));
 }
 
@@ -334,7 +332,6 @@ void ChatBackend::selectConversation(QString conversationId)
     // members. refreshMembers then loads the new group's roster when it can, and
     // keeps the last-known one across a transient offline of the same group.
     // User-driven, so its synchronous read is safe here (not in an event callback).
-    m_pendingMembers.clear();
     m_memberModel->clear();
     setMemberCount(0);
     refreshMembers();
@@ -359,24 +356,22 @@ void ChatBackend::refreshMembers()
     const QVariantList members = modules().chat_module.list_group_members(convoId);
     QVector<MemberItem> rows;
     rows.reserve(members.size());
-    QSet<QString> committed;
+    int committed = 0;
     for (const QVariant& v : members) {
-        const QString address = v.toMap().value(QStringLiteral("address")).toString();
+        const QVariantMap record = v.toMap();
+        const QString address = record.value(QStringLiteral("address")).toString();
+        const bool pending = record.value(QStringLiteral("pending")).toBool();
         // An empty address is the roster's "no confirmed account" signal; keep
         // it — the model renders it as "unknown_account". Only a real account
         // address can be self.
-        rows.append({ address, !address.isEmpty() && address == m_myAddress, false });
-        if (!address.isEmpty())
-            committed.insert(address);
+        rows.append({ address, !address.isEmpty() && address == m_myAddress, pending });
+        if (!pending)
+            ++committed;
     }
-    // Drop invites that have since committed; show the rest as busy rows.
-    m_pendingMembers.subtract(committed);
-    for (const QString& address : std::as_const(m_pendingMembers))
-        rows.append({ address, false, true });
 
     m_memberModel->setMembers(rows);
     // Committed roster size only; pending invites appear in the list but aren't counted.
-    setMemberCount(static_cast<int>(members.size()));
+    setMemberCount(committed);
 }
 
 // ── event handlers ────────────────────────────────────────────────────────────

--- a/src/ChatBackend.h
+++ b/src/ChatBackend.h
@@ -2,7 +2,6 @@
 #define CHAT_BACKEND_H
 
 #include <QObject>
-#include <QSet>
 #include <QSortFilterProxyModel>
 #include <QString>
 #include <QVariantList>
@@ -90,8 +89,6 @@ private:
     // This installation's own address, cached lazily on first roster refresh to
     // mark the self entry.
     QString m_myAddress;
-    // Addresses invited into the current group but not yet committed to its roster.
-    QSet<QString> m_pendingMembers;
     bool m_moduleInitialised = false;
     // Set once the initial snapshot has loaded; gates the reconnect resync in
     // applyDeliveryState so it doesn't fire during initial setup.

--- a/src/ChatBackend.rep
+++ b/src/ChatBackend.rep
@@ -17,9 +17,10 @@ class ChatBackend
     PROP(bool currentIsGroup READONLY)
     PROP(QString currentDisplayName READONLY)
     PROP(QString currentDescription READONLY)
-    // The current group's roster size. Exposed as a property (not read off
-    // memberModel) because the model reaches QML as a QtRO replica whose
-    // rowCount() a non-view caller can't rely on.
+    // How many members the current group has committed; pending invites are
+    // listed in memberModel but not counted here. Exposed as a property (not
+    // read off memberModel) because the model reaches QML as a QtRO replica
+    // whose rowCount() a non-view caller can't rely on.
     PROP(int memberCount READONLY)
 
     SLOT(void createConversation(QString peerAddress))

--- a/src/MemberListModel.cpp
+++ b/src/MemberListModel.cpp
@@ -58,7 +58,7 @@ void MemberListModel::clear()
 bool MemberListModel::contains(const QString& address) const
 {
     for (const auto& item : m_items) {
-        if (item.address == address)
+        if (!item.pending && item.address == address)
             return true;
     }
     return false;

--- a/src/MemberListModel.h
+++ b/src/MemberListModel.h
@@ -38,6 +38,8 @@ public:
 
     void setMembers(const QVector<MemberItem>& members);
     void clear();
+    // True when `address` is a committed member. A pending invite does not
+    // count: it cannot take part in the conversation until the group commits it.
     bool contains(const QString& address) const;
 
 private:

--- a/src/qml/ChatUi/MembersPane.qml
+++ b/src/qml/ChatUi/MembersPane.qml
@@ -13,7 +13,7 @@ import Logos.Controls
 Rectangle {
     id: root
 
-    // The MemberListModel (roles: address, label, isSelf).
+    // The MemberListModel (roles: address, label, isSelf, pending).
     required property var memberModel
     // Whether the backend is online; gates the add-member controls.
     required property bool online


### PR DESCRIPTION
The pending marker was tracked in the backend as a single set of addresses for whichever conversation was open, so switching away had to clear it or its rows would leak into the next group. Coming back re-read the roster from the module, which listed committed members only, and the invite vanished from the panel until the group committed it minutes later.

The module's roster now flags an invite it has not committed yet, so the marker is read per conversation from the module instead of being tracked here, and survives any number of switches. memberCount stays committed-only, and a pending invite no longer counts as being on the roster when a message arrives from an address the panel has not seen.


---

Pinned to chat_module `0678a31f956dc486172c6764fae99e98f6583f27`, the head of logos-co/logos-chat-module#56, which adds the pending flag this reads; that in turn pins logos-messaging/libchat#188. Re-pin down the chain as each lands, before merging.
