### PR TITLE
ci: switch the Nix cache from Cachix to Attic via setup-nix-cache-action

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   doctests:
     name: doc-tests (${{ matrix.os }})
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -45,14 +46,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       # Resolve the commit under test. For pull requests this is the PR's head
       # commit (not the synthetic merge commit); for pushes it's the pushed

--- a/.github/workflows/group-chat.yml
+++ b/.github/workflows/group-chat.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   group:
     name: group chat (ubuntu-latest)
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -33,14 +34,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       # The flow runs against the commit under test (FLAKE defaults to the
       # checked-out tree) and needs a real network: the three delivery nodes find

--- a/.github/workflows/qml-checks.yml
+++ b/.github/workflows/qml-checks.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   qml-checks:
     name: qmllint + Qt Quick Test
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -33,14 +34,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       # Build the standalone app to obtain the design system the plugin QML
       # imports. The app exposes no buildable package attr, so recover its

--- a/.github/workflows/two-instance-exchange.yml
+++ b/.github/workflows/two-instance-exchange.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   exchange:
     name: two-instance exchange (ubuntu-latest)
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -33,14 +34,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       # The exchange runs against the commit under test (FLAKE defaults to the
       # checked-out tree) and needs a real network: the two delivery nodes find

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "Logos Chat UI - QML view + C++ backend module";
 
+  nixConfig = {
+    extra-substituters = [ "https://cache.nix.logos.co/public" ];
+    extra-trusted-public-keys = [ "public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=" ];
+  };
+
   inputs = {
     # Follow chat_module's own builder, so the logos-protocol/logos-qt-sdk
     # chain matches across both.


### PR DESCRIPTION
Same as logos-co/logos-chat-module#57 and logos-co/logos-delivery-module#69, using [`setup-nix-cache-action@v1`](https://github.com/logos-co/setup-nix-cache-action).

Note: this repo is not yet in [infra-ci `attic_repos`](https://github.com/status-im/infra-ci/blob/master/ansible/group_vars/attic.yml), so the Attic secrets don't exist yet — pulls work anonymously, publishing activates once infra onboards the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)