### PR TITLE
chore: release 0.2.1 against the chat_module v0.2.1 tag

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,17 +6,17 @@
         "logos-module-builder": "logos-module-builder_4"
       },
       "locked": {
-        "lastModified": 1785433739,
-        "narHash": "sha256-uF26dHe+DM1uIL52TuDOTGqd/Cu+v/qciagcDjN7wo8=",
+        "lastModified": 1785477332,
+        "narHash": "sha256-vSOu820wX1RdN3FhDtR4+532KUlgzYICLjbS26E5SJc=",
         "owner": "logos-co",
         "repo": "logos-chat-module",
-        "rev": "904fc78c9f346a6d23028c0978d9c29a080f3339",
+        "rev": "894526024dadd641a88a7b3b23de6a1edb8a8dff",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
+        "ref": "v0.2.1",
         "repo": "logos-chat-module",
-        "rev": "904fc78c9f346a6d23028c0978d9c29a080f3339",
         "type": "github"
       }
     },
@@ -3215,11 +3215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784762341,
-        "narHash": "sha256-sFFXe4cprvrynEyfMi4TDLJPtDkd069YpwByhC3YbD8=",
+        "lastModified": 1785085094,
+        "narHash": "sha256-7FRDx7SptIKxgj5ha39FfZ1DzOb43xabTZG/zXibJKw=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "2e31eeb1ac2c55245fbaa3030ff0a164fb68dd06",
+        "rev": "8a40a9832251840d96e121abdc9e6bd760bc5afd",
         "type": "github"
       },
       "original": {
@@ -4405,11 +4405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782492700,
-        "narHash": "sha256-Cfu9C6wMubyWTDLEh738rfCt3CuI91BZNWLj2GfTXAY=",
+        "lastModified": 1785353260,
+        "narHash": "sha256-z8NPSvBNM7AxcNTqTc/DdvFAXLeHiZ12enSgjh3qU40=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "350a2891e60a40aba93f273d85e8accb4803ac29",
+        "rev": "5f63af681ac4805d059332b63e6191c4a8e2820d",
         "type": "github"
       },
       "original": {
@@ -4978,11 +4978,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785226136,
-        "narHash": "sha256-jU7on18BFpAr9NrEDmjO1bD4kuoXQ8wZa21UHpTz+Yk=",
+        "lastModified": 1785412141,
+        "narHash": "sha256-wMcOKRjx1u9WiSa31eR1Bm6O2zturwCvHLMpDGe7VDc=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "8e67643446dbadfa2fd20c77d454e2ced83ccdc4",
+        "rev": "73e482bbfe9b946d19d7a70d7b80e6f94a588889",
         "type": "github"
       },
       "original": {
@@ -5260,11 +5260,11 @@
         "process-stats": "process-stats_18"
       },
       "locked": {
-        "lastModified": 1784715696,
-        "narHash": "sha256-TFPRFxFyl7nskaPsuQJrIB9IZzKLSWIiPeNfy15Sptw=",
+        "lastModified": 1785443983,
+        "narHash": "sha256-eRRAXlWcZs4gpK3Nny2CtvpD04bDE8OxA4baMZxhwBk=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "be221c5749036343909fa0b109edecfb4d329fdd",
+        "rev": "4ef9736a1e6a8c05de53fa13d9acf5f4d4570833",
         "type": "github"
       },
       "original": {
@@ -7790,15 +7790,16 @@
         "rust-overlay": "rust-overlay_7"
       },
       "locked": {
-        "lastModified": 1785226253,
-        "narHash": "sha256-+LYrdJzPEqVUpPM+T4C6Cp9dGiciPePcfYr4TnPpIfE=",
+        "lastModified": 1785449814,
+        "narHash": "sha256-7JFJQrUqy/uKiVKmYiiMUSSwDIrBZQEmN1x5R2JsmdA=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "3dd6b3a01ee2dc72c6043a85349d749bd6258f79",
+        "rev": "2b59cb8e855894f7e7a064b15bfae409f288080b",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
+        "ref": "0.2.6",
         "repo": "logos-module-builder",
         "type": "github"
       }
@@ -11368,11 +11369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782766905,
-        "narHash": "sha256-oYE7sMr7PS+kDoX//Cx90HmRiRHBnHONx6r4Ekkc7DI=",
+        "lastModified": 1785441994,
+        "narHash": "sha256-1MEdhIIcg4LuMmigdbHhiIrl6qc9vjiMd9vdyBUt7/w=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "2ec64c4a65f8966b5137cdba3a19a6498ce17b6d",
+        "rev": "9fb81c52289ced9241e707c041f6bb2e96d66a64",
         "type": "github"
       },
       "original": {
@@ -30846,11 +30847,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784753092,
-        "narHash": "sha256-cxl80GhIEd4U5R24ROJyDhj9zDpJ/oKCTd18oHWQREU=",
+        "lastModified": 1785065460,
+        "narHash": "sha256-cp5Un0NBXwNoK/+atBLMl4NwCfDXzy0KMpyUOtK6pcc=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "8ede8ece0817265c93297393febe6d908f8eb179",
+        "rev": "ae2f7e1b5842d62836091c6dc0c903508806456e",
         "type": "github"
       },
       "original": {
@@ -31102,11 +31103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782490644,
-        "narHash": "sha256-IRHFIBa/+a10tVNEexm6DDZ0JPF8YQgUbxWoNwIytt4=",
+        "lastModified": 1785261709,
+        "narHash": "sha256-dcI6zmGy5+99MB9TaN7KGJkbvDWV8WT+B/8b5UPLjkE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "d5d58e7e230768505c683150f651358612abd442",
+        "rev": "362b03fb1ec25b35ed5d630670f5fd2bd899b196",
         "type": "github"
       },
       "original": {
@@ -31233,11 +31234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784686752,
-        "narHash": "sha256-YfIUX0xYtvp7FrvYJtBDDZNzQsCPihWEZ6GxvKwVifA=",
+        "lastModified": 1785352565,
+        "narHash": "sha256-i5ynBtNk6Qe+YSHsa+O8DjnLpHXDVqyLGPxBAImipD8=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "6401e30ae1cfabac77285ee8e7a82c2cef3858f1",
+        "rev": "4ee85b26a65e331821823f6435135c088a1bf447",
         "type": "github"
       },
       "original": {
@@ -31262,11 +31263,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784753092,
-        "narHash": "sha256-cxl80GhIEd4U5R24ROJyDhj9zDpJ/oKCTd18oHWQREU=",
+        "lastModified": 1785261709,
+        "narHash": "sha256-dcI6zmGy5+99MB9TaN7KGJkbvDWV8WT+B/8b5UPLjkE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "8ede8ece0817265c93297393febe6d908f8eb179",
+        "rev": "362b03fb1ec25b35ed5d630670f5fd2bd899b196",
         "type": "github"
       },
       "original": {
@@ -32630,11 +32631,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784687933,
-        "narHash": "sha256-GECc9sqeFWYQdya1/QDH0NThHRidy6MRIBAIaO7AAyE=",
+        "lastModified": 1785272352,
+        "narHash": "sha256-Wp6Gmsk+GlpwrR1giqPvpkJqBaBsEKJ+pkmbziTD6kQ=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "2ec59459a3a6ad541eab1b3b10861ae76575e488",
+        "rev": "af767b7ea7e083d7a67c712826fb71926e5393e0",
         "type": "github"
       },
       "original": {
@@ -32672,11 +32673,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784762357,
-        "narHash": "sha256-SozQr27TzKAk0WxNiXHC/CvXkuB2ovu81/VLsiDhvUg=",
+        "lastModified": 1785067154,
+        "narHash": "sha256-Dor9bXpFDA90uU3fO5mQ9GV9s39ufVBSEk6nq2kLW08=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "92bd4491041485efda6e1a2061629ea438af07ab",
+        "rev": "09365f5e048b75422c7a95169c03b82bdea3b918",
         "type": "github"
       },
       "original": {
@@ -34023,11 +34024,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784893078,
-        "narHash": "sha256-YjevhScunKXm2OdHuBMRaGJSDpjAUkdPKDh8WsmVDwE=",
+        "lastModified": 1785446911,
+        "narHash": "sha256-nc+ICu6O9s8B9tA3OKyUI45j5Ro+KMPDFrRz04DD3+M=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "0d4b65212196ad3fdeea76ac5c2756e2397ed9da",
+        "rev": "e4eb3c00d2f1512c9043c88bd5f38dafd0f51b41",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,10 @@
     # Follow chat_module's own builder, so the logos-protocol/logos-qt-sdk
     # chain matches across both.
     logos-module-builder.follows = "chat_module/logos-module-builder";
-    # Pinned to the chat_module rev that writes the chat core's account of a run
-    # into its instance directory and names the file through get_log_path(), and
-    # that answers health(). Without it libchat's events are dropped in the
-    # module's process, this view has no directory to write its own log beside,
-    # and a module that dies goes unnoticed until the next call times out.
-    chat_module.url = "github:logos-co/logos-chat-module/904fc78c9f346a6d23028c0978d9c29a080f3339";
+    # Pinned to the v0.2.1 release tag: this view and the module it renders are
+    # released in lockstep, so the module built here is the release the package
+    # manager resolves.
+    chat_module.url = "github:logos-co/logos-chat-module/v0.2.1";
     # Follow chat_module's delivery pin, so both build against the same
     # delivery module.
     logos-delivery-module.follows = "chat_module/logos-delivery-module";

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "chat_ui",
   "display_name": "Chat",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "ui_qml",
   "interface": "universal",
   "category": "chat",


### PR DESCRIPTION
Releases the view as 0.2.1 and builds it against the `chat_module` v0.2.1 release tag, so the view and the module it renders ship in lockstep.

`metadata.json` keeps declaring its dependencies by name. Naming a version means writing an object entry, `{"name": …, "version": …}`, and the C++ generator that builds this view's backend still reads such an entry as an empty name and drops it, leaving `LogosModules` without the member the backend calls through (logos-cpp-sdk#123, open). chat_module 0.2.1 dropped its own version constraint on `delivery_module` for the same reason. Both go back once the generator has the fix.

The relock brings the module builder's 0.2.6 release, which this view follows through `chat_module`, and the logos-module and liblogos revs under it.